### PR TITLE
第8章 実装を隠す

### DIFF
--- a/part1/chapter8/dollar.go
+++ b/part1/chapter8/dollar.go
@@ -1,0 +1,9 @@
+package chapter8
+
+type dollar struct {
+	money
+}
+
+func (d dollar) times(multiplier int) Money {
+	return newMoney(Dollar, d.amount*multiplier)
+}

--- a/part1/chapter8/franc.go
+++ b/part1/chapter8/franc.go
@@ -1,0 +1,9 @@
+package chapter8
+
+type franc struct {
+	money
+}
+
+func (f franc) times(multiplier int) Money {
+	return newMoney(Franc, f.amount*multiplier)
+}

--- a/part1/chapter8/money.go
+++ b/part1/chapter8/money.go
@@ -1,0 +1,42 @@
+package chapter8
+
+type Currency int
+
+const (
+	Dollar = iota
+	Franc
+)
+
+type Money interface {
+	times(int) Money
+	equals(Money) bool
+	getAmount() int
+	getCurrency() Currency
+}
+
+type money struct {
+	amount   int
+	currency Currency
+}
+
+func newMoney(currency Currency, amount int) Money {
+	m := money{amount: amount, currency: currency}
+
+	if currency == Franc {
+		return franc{m}
+	}
+
+	return dollar{m}
+}
+
+func (m money) equals(money Money) bool {
+	return m.amount == money.getAmount() && m.currency == money.getCurrency()
+}
+
+func (m money) getAmount() int {
+	return m.amount
+}
+
+func (m money) getCurrency() Currency {
+	return m.currency
+}

--- a/part1/chapter8/money_test.go
+++ b/part1/chapter8/money_test.go
@@ -1,0 +1,74 @@
+package chapter8
+
+import (
+	"testing"
+)
+
+func TestMultiplication(t *testing.T) {
+
+	testCases := []struct {
+		desc string
+		in   int
+		want int
+	}{
+		{"$5*2=10となること", 2, 10},
+		{"$5*3=15となること", 3, 15},
+	}
+
+	five := newMoney(Dollar, 5)
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			if got, want := five.times(test.in), newMoney(Dollar, test.want); got != want {
+				t.Errorf("Money.doller.times(): got %v want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestEquality(t *testing.T) {
+
+	testCases := []struct {
+		desc         string
+		currencySrc  Currency
+		currencyDest Currency
+		in           int
+		want         bool
+	}{
+		{"5ドルと5ドルが同じ価値であること", Dollar, Dollar, 5, true},
+		{"5ドルと6ドルが異なる価値であること", Dollar, Dollar, 6, false},
+		{"5CHFと5CHFが同じ価値であること", Franc, Franc, 5, true},
+		{"5CHFと6CHFが異なる価値であること", Franc, Franc, 6, false},
+		{"5ドルと5CHFが異なる価値であること", Dollar, Franc, 5, false},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			if got := newMoney(test.currencySrc, 5).equals(newMoney(test.currencyDest, test.in)); got != test.want {
+				t.Errorf("Money.equals(): got %v want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestFrancMultiplication(t *testing.T) {
+
+	testCases := []struct {
+		desc string
+		in   int
+		want int
+	}{
+		{"5CHF*2=10となること", 2, 10},
+		{"5CHF*3=15となること", 3, 15},
+	}
+
+	five := newMoney(Franc, 5)
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			if got, want := five.times(test.in), newMoney(Franc, test.want); got != want {
+				t.Errorf("Money.franc.times(): got %v want %v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# TODOリスト
- [ ] $5 + 10CHF = $10（レートが2 : 1の場合）
- [x] $5 * 2 = 10
- [x] `amount` をprivateにする
- [x] `Dollar` の副作用どうする？
- [ ] `Money` の丸め処理どうする？
- [x] `equals()`
- [ ] `hasCode()`
- [ ] null との等価性比較
- [ ] 他のオブジェクトとの等価性比較
- [x] 5CHF * 2 = 10CHF
- [ ] `Dollar` と `Franc` の重複
- [x] `equals` の一般化
- [ ] `times` の一般化
- [x] `Franc` と `Dollar` を比較する
- [ ] 通貨の概念
- [ ] `testFrancMultiplication` を削除する？

# Note
書籍ではFactory Methodを使用して、テストコードから2つのサブクラスの存在を隠しているが、 `newMoney` で満たしていると考えてコードの修正は行っていない。
Factory Methodを使用した書き方がピンと来てないことも理由の1つ 😅 