### PR TITLE
第22章 失敗の扱い

### DIFF
--- a/part2/chapter22/xunit.go
+++ b/part2/chapter22/xunit.go
@@ -41,7 +41,11 @@ func (t *TestCase) run(w *WasRun) *TestResult {
 	w.setUp()
 	method := t.name
 	fv := reflect.ValueOf(w).MethodByName(method)
-	fv.Call(nil)
+	res := fv.Call(nil)
+	err := res[0].Interface()
+	if err != nil {
+		result.testFailed()
+	}
 	w.tearDown()
 	return result
 }
@@ -58,8 +62,9 @@ func (w *WasRun) setUp() {
 	w.log += "setUp "
 }
 
-func (w *WasRun) TestMethod() {
+func (w *WasRun) TestMethod() error {
 	w.log += "testMethod "
+	return nil
 }
 
 func (w *WasRun) TestBrokenMethod() error {

--- a/part2/chapter22/xunit.go
+++ b/part2/chapter22/xunit.go
@@ -1,0 +1,67 @@
+package chapter22
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+type TestResult struct {
+	runCount int
+}
+
+func newTestResult() *TestResult {
+	return &TestResult{runCount: 0}
+
+}
+
+func (t *TestResult) testStarted() {
+	t.runCount++
+}
+
+func (t *TestResult) summary() string {
+	return fmt.Sprintf("%v run, 0 failed", t.runCount)
+}
+
+type TestCase struct {
+	name string
+}
+
+func newTestCase(name string) *TestCase {
+	return &TestCase{name: name}
+}
+
+func (t *TestCase) run(w *WasRun) *TestResult {
+	result := newTestResult()
+	result.testStarted()
+	w.setUp()
+	method := t.name
+	fv := reflect.ValueOf(w).MethodByName(method)
+	fv.Call(nil)
+	w.tearDown()
+	return result
+}
+
+type WasRun struct {
+	log string
+}
+
+func newWasRun() *WasRun {
+	return &WasRun{}
+}
+
+func (w *WasRun) setUp() {
+	w.log += "setUp "
+}
+
+func (w *WasRun) TestMethod() {
+	w.log += "testMethod "
+}
+
+func (w *WasRun) TestBrokenMethod() error {
+	return errors.New("Exception")
+}
+
+func (w *WasRun) tearDown() {
+	w.log += "tearDown "
+}

--- a/part2/chapter22/xunit.go
+++ b/part2/chapter22/xunit.go
@@ -7,20 +7,24 @@ import (
 )
 
 type TestResult struct {
-	runCount int
+	runCount   int
+	errorCount int
 }
 
 func newTestResult() *TestResult {
-	return &TestResult{runCount: 0}
-
+	return &TestResult{runCount: 0, errorCount: 0}
 }
 
 func (t *TestResult) testStarted() {
 	t.runCount++
 }
 
+func (t *TestResult) testFailed() {
+	t.errorCount++
+}
+
 func (t *TestResult) summary() string {
-	return fmt.Sprintf("%v run, 0 failed", t.runCount)
+	return fmt.Sprintf("%v run, %v failed", t.runCount, t.errorCount)
 }
 
 type TestCase struct {

--- a/part2/chapter22/xunit_test.go
+++ b/part2/chapter22/xunit_test.go
@@ -1,0 +1,40 @@
+package chapter22
+
+import (
+	"testing"
+)
+
+func TestTemplateMethod(testing *testing.T) {
+	testcase := newTestCase("TestMethod")
+	test := newWasRun()
+
+	testcase.run(test)
+
+	if got, want := test.log, "setUp testMethod tearDown "; got != want {
+		testing.Errorf("got %v want %v", got, want)
+	}
+}
+
+func TestSummary(testing *testing.T) {
+	testcase := newTestCase("TestMethod")
+	test := newWasRun()
+
+	result := testcase.run(test)
+
+	if got, want := result.summary(), "1 run, 0 failed"; got != want {
+		testing.Errorf("got %v want %v", got, want)
+	}
+}
+
+/*
+func TestFailedSummary(testing *testing.T) {
+	testcase := newTestCase("TestBrokenMethod")
+	test := newWasRun()
+
+	result := testcase.run(test)
+
+	if got, want := result.summary(), "1 run, 1 failed"; got != want {
+		testing.Errorf("got %v want %v", got, want)
+	}
+}
+*/

--- a/part2/chapter22/xunit_test.go
+++ b/part2/chapter22/xunit_test.go
@@ -26,6 +26,17 @@ func TestSummary(testing *testing.T) {
 	}
 }
 
+func TestFailedResultFormatting(testing *testing.T) {
+	result := newTestResult()
+
+	result.testStarted()
+	result.testFailed()
+
+	if got, want := result.summary(), "1 run, 1 failed"; got != want {
+		testing.Errorf("got %v want %v", got, want)
+	}
+}
+
 /*
 func TestFailedSummary(testing *testing.T) {
 	testcase := newTestCase("TestBrokenMethod")


### PR DESCRIPTION
## TODO
- [x] テストメソッドを呼び出す
- [x] `setUp` を最初に呼び出す
- [x] `tearDown` を後で呼び出す
- [ ] テストメソッドが失敗したとしても `tearDown` を呼び出す
- [ ] 複数のテストを走らせる
- [x] 収集したテスト結果を出力する
- [x] `WasRun` で文字列をログに記録する
- [x] 失敗したテストを出力する
- [ ] setUpのエラーをキャッチして出力する